### PR TITLE
Set bindgen version to 0 to avoid linking error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.48.1"
+bindgen = "0"
 log = "0.4.6"
 pkg-config = "0.3.14"
 


### PR DESCRIPTION
This is a hack, but it's the best we can do for now